### PR TITLE
Fix/#130/carousel layout error

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.6.2",
     "react-infinite-scroll-hook": "^4.0.1",
-    "react-slick": "^0.28.1",
     "react-toastify": "^7.0.4",
-    "slick-carousel": "^1.8.1",
     "styled-components": "^5.2.3"
   },
   "devDependencies": {
@@ -57,7 +55,6 @@
     "@types/react": "^17.0.6",
     "@types/react-dom": "^17.0.5",
     "@types/react-infinite-scroller": "^1.2.1",
-    "@types/react-slick": "^0.23.4",
     "@types/styled-components": "^5.1.9",
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,8 +12,6 @@ import { ToastContainer, cssTransition } from 'react-toastify'
 
 import 'normalize.css'
 import 'antd/dist/antd.css'
-import 'slick-carousel/slick/slick.css'
-import 'slick-carousel/slick/slick-theme.css'
 import 'react-toastify/dist/ReactToastify.min.css'
 import 'animate.css/animate.min.css'
 import 'src/styles/custom-antd.css'

--- a/src/pages/feed/index.tsx
+++ b/src/pages/feed/index.tsx
@@ -123,7 +123,7 @@ function StoresFeedPage() {
             centered
             onTabClick={(activeKey) => router.push(goToPage(activeKey))}
             size="large"
-            tabBarStyle={{ color: '#b4b4b4'}}
+            tabBarStyle={{ color: '#b4b4b4' }}
           >
             <Tabs.TabPane tab="매장 소식" key="feed" />
             <Tabs.TabPane tab="리뷰 소식" key="review-feed" />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,5 @@
-import LocationOnRoundedIcon from '@material-ui/icons/LocationOnRounded'
-import SearchRoundedIcon from '@material-ui/icons/SearchRounded'
-import NotificationsRoundedIcon from '@material-ui/icons/NotificationsRounded'
 import ExpandMoreRoundedIcon from '@material-ui/icons/ExpandMoreRounded'
 import IconButton from '@material-ui/core/IconButton'
-import LocalActivityRoundedIcon from '@material-ui/icons/LocalActivityRounded'
 import LocalGroceryStoreRoundedIcon from '@material-ui/icons/LocalGroceryStoreRounded'
 import grey from '@material-ui/core/colors/grey'
 import styled from 'styled-components'
@@ -30,14 +26,6 @@ import { Tabs, Carousel, Divider, Tag, Checkbox } from 'antd'
 import { SelectedPreferenceButton } from 'src/pages/users/[name]/preferences/index'
 
 const { TabPane } = Tabs
-
-const contentStyle: CSSProperties = {
-  height: '150px',
-  color: '#929393',
-  lineHeight: '150px',
-  background: '#EAEAEA',
-  textAlign: 'center',
-}
 
 const FlexContainerBetweenCenter = styled(FlexContainerBetween)`
   align-items: center;
@@ -264,7 +252,13 @@ function HomePage() {
           tabBarStyle={{ color: '#929393', paddingLeft: '1.5rem' }}
         >
           <TabPane tab="디저트핏" key="1">
-            <Carousel>
+            <Carousel autoplay>
+              <BannerFrame>
+                <Image src="/bannerad.png" alt="banner_ad" layout="fill" objectFit="cover" />
+              </BannerFrame>
+              <BannerFrame>
+                <Image src="/banner.png" alt="banner_ad" layout="fill" objectFit="cover" />
+              </BannerFrame>
               <BannerFrame>
                 <Image src="/bannerad.png" alt="banner_ad" layout="fill" objectFit="cover" />
               </BannerFrame>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -113,6 +113,7 @@ const StyledTag = styled.span<{ color: string }>`
   vertical-align: middle;
   background-color: ${(p) => p.color};
 `
+
 const BannerFrame = styled.div`
   padding-top: 30%;
   position: relative;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,7 @@ import useInfiniteScroll from 'react-infinite-scroll-hook'
 import MenuCard, { MenuLoadingCard } from 'src/components/MenuCard'
 import TopHeader from 'src/components/TopHeader'
 import useBoolean from 'src/hooks/useBoolean'
+import Image from 'next/image'
 import { useState, useContext, CSSProperties } from 'react'
 import { FlexContainerBetween, FlexContainerAlignCenter } from 'src/styles/FlexContainer'
 import { HEADER_HEIGHT, TABLET_MIN_WIDTH } from 'src/models/constants'
@@ -112,10 +113,11 @@ const StyledTag = styled.span<{ color: string }>`
   vertical-align: middle;
   background-color: ${(p) => p.color};
 `
-const BannerImg = styled.img`
-  width: 100%;
-  height: 100%;
+const BannerFrame = styled.div`
+  padding-top: 30%;
+  position: relative;
 `
+
 const FixedPosition = styled.div`
   position: fixed;
   left: 50%;
@@ -261,11 +263,13 @@ function HomePage() {
           tabBarStyle={{ color: '#929393', paddingLeft: '1.5rem' }}
         >
           <TabPane tab="디저트핏" key="1">
-            <Carousel autoplay>
-              <BannerImg src="bannerad.png" alt="banner_ad" />
-              <BannerImg src="bannerad.png" alt="banner_ad" />
-              <BannerImg src="bannerad.png" alt="banner_ad" />
-              <BannerImg src="bannerad.png" alt="banner_ad" />
+            <Carousel>
+              <BannerFrame>
+                <Image src="/bannerad.png" alt="banner_ad" layout="fill" objectFit="cover" />
+              </BannerFrame>
+              <BannerFrame>
+                <Image src="/banner.png" alt="banner_ad" layout="fill" objectFit="cover" />
+              </BannerFrame>
             </Carousel>
             <MiddleGrid>
               <FlexContainerBetween>

--- a/src/pages/users/[name]/regulars/index.tsx
+++ b/src/pages/users/[name]/regulars/index.tsx
@@ -64,9 +64,7 @@ function UserRegularStoresPage() {
             <FlexContainerAlignCenter>
               <ArrowBackIosRoundedIcon style={StyledArrowBackIosRoundedIcon} onClick={goBack} />
             </FlexContainerAlignCenter>
-            <FlexContainerAlignCenter>
-              단골
-            </FlexContainerAlignCenter>
+            <FlexContainerAlignCenter>단골</FlexContainerAlignCenter>
             <WhiteText>ㅇ</WhiteText>
           </FlexContainerBetween1>
         </TopHeader>

--- a/src/styles/custom-antd.css
+++ b/src/styles/custom-antd.css
@@ -7,6 +7,7 @@
   background: #ff9a88;
 }
 
+.ant-tabs-tab:hover,
 .ant-tabs-tab-btn:focus,
 .ant-tabs-tab-remove:focus,
 .ant-tabs-tab-btn:hover,
@@ -33,5 +34,13 @@
 }
 
 .ant-carousel .slick-dots {
-  margin-left: 0%;
+  z-index: 0;
+}
+
+.ant-carousel .slick-dots li {
+  box-shadow: 0 0 0 1px rgb(255 154 136 / 25%);
+}
+
+.ant-carousel .slick-dots li.slick-active button {
+  background: #ff9a88;
 }


### PR DESCRIPTION
### 개발 완료한 점 (스크린샷)

#### Carousel

![image](https://user-images.githubusercontent.com/33145190/120894029-3f34af00-c651-11eb-9f56-3883117db5ae.png)

- carousel 가로세로비 3:1 로 고정
- z-index 0
- carousel 버튼 색 변경

#### Dessert Fit

![image](https://user-images.githubusercontent.com/33145190/120894127-df8ad380-c651-11eb-91bd-6790fc00ef52.png)

- 로그인 전에는 버튼 없앰
- 텍스트 정렬 및 폰트 크기 수정

### 보완할 점

아직 개발해야 할 점
